### PR TITLE
Note that API-Level 30 and above requires queries declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ These informations are stored in the file `positions.log`, as detailed below in 
 ![Example of AIDL file](resources/images/AIDL.png)
 
 - Add the AIDL file under the Java package: `it.cnr.isti.steplogger`
+- If your application is built with API Level 30 and above, declare that you're using the StepLoggerService in your `AndroidManifest.xml`:
+		
+		<queries>
+  			<package android:name="it.cnr.isti.steplogger" />
+		</queries>
+
 - Invoke the `logPosition` method by following these steps:
 	- Create an Intent object
 	- Set the class name of the intent object with:


### PR DESCRIPTION
[API Level 30 and above requires the declaration of consumed services](https://developer.android.com/guide/topics/manifest/queries-element) in the consuming application's `AndroidManifest.xml` file. Otherwise, service binding will silently fail.
I think adding it to the README makes sense (at least I would've benefited from it :sweat_smile:).

In the manifest, it looks like this:
```xml
[...]
</application>
<queries>
    <package android:name="it.cnr.isti.steplogger" />
</queries>
<uses-permission android:name="android.permission.XXX" />
[...]
```